### PR TITLE
Add database export method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,6 @@
   <packaging>jar</packaging>
 
   <properties>
-    <wsd.ypid>20084</wsd.ypid>
-
     <guava.version>14.0.1</guava.version>
     <oneandone.java.source>1.7</oneandone.java.source>
     <oneandone.java.target>1.7</oneandone.java.target>
@@ -92,6 +90,11 @@
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-queryparser</artifactId>
       <version>4.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.3.1</version>
     </dependency>
     <!-- this is used by lucense-sandbox, but the dependency is not fetched transitivly ... -->
     <dependency>

--- a/src/main/java/net/oneandone/pommes/cli/DatabaseExport.java
+++ b/src/main/java/net/oneandone/pommes/cli/DatabaseExport.java
@@ -1,0 +1,38 @@
+package net.oneandone.pommes.cli;
+import java.util.List;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.WildcardQuery;
+
+import com.google.gson.Gson;
+
+import net.oneandone.pommes.model.Database;
+import net.oneandone.pommes.model.Pom;
+import net.oneandone.sushi.cli.Console;
+import net.oneandone.sushi.cli.Value;
+import net.oneandone.sushi.fs.Node;
+public class DatabaseExport extends Base {
+
+    private final Gson gson = new Gson();
+    @Value(name = "exportPath", position = 2)
+    private String exportPath;
+    @Value(name = "scmSubstring", position = 1)
+    private String scmSubstring;
+    public DatabaseExport(Console console, Environment environment) {
+        super(console, environment);
+    }
+    @Override
+    public void invoke(Database database) throws Exception {
+        Node export = console.world.node(exportPath);
+        console.verbose.println("Selecting all documents with " + scmSubstring + " in its origin");
+        List<Pom> poms = database.query(new WildcardQuery(new Term(Database.ORIGIN, "*" + scmSubstring + "*")));
+        console.verbose.println("Got " + poms.size() + " doucments");
+        Node temp = console.world.getTemp().createTempFile();
+        temp.writeLines(gson.toJson(poms));
+        console.verbose.println("Wrote temp file " + temp.getPath());
+        console.verbose.println("Saving to  " + export.getPath());
+        temp.copyFile(export);
+        console.verbose.println("Saving done.");
+
+    }
+}

--- a/src/main/java/net/oneandone/pommes/cli/Main.java
+++ b/src/main/java/net/oneandone/pommes/cli/Main.java
@@ -15,14 +15,14 @@
  */
 package net.oneandone.pommes.cli;
 
+import java.io.IOException;
+
 import net.oneandone.sushi.cli.Child;
 import net.oneandone.sushi.cli.Cli;
 import net.oneandone.sushi.cli.Command;
 import net.oneandone.sushi.cli.Option;
 import net.oneandone.sushi.fs.World;
 import net.oneandone.sushi.fs.file.FileNode;
-
-import java.io.IOException;
 
 public class Main extends Cli implements Command {
     public static void main(String[] args) throws IOException {
@@ -98,6 +98,10 @@ public class Main extends Cli implements Command {
         return new DatabaseRemove(console, env());
     }
 
+    @Child("database-export")
+    public DatabaseExport export() throws IOException {
+        return new DatabaseExport(console, env());
+    }
     //--
 
     @Override


### PR DESCRIPTION
Hi,

i added a command to export a subset of the database to a json-file.
Example command: 
`pommes -v database-export trunk controlpanel-pommes.json`
the first parameter defines the subset, using a wildcard-matcher for the scm-origin of the pom. The second argument is the target location.

This extends pomes to be used in-depended in other tools.

Regards, Max